### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["system"],
   "description": "Adds project from ecosystem, works with all project types: images / videos / 3d / dicom",
-  "docker_image": "supervisely/system:6.73.554",
+  "docker_image": "supervisely/system:6.73.564",
   "main_script": "src/add_project.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {
@@ -18,5 +18,5 @@
   "icon": "https://user-images.githubusercontent.com/12828725/192745216-b395679c-de58-47a2-963a-b43378b5680b.png",
   "icon_background": "#FFFFFF",
   "headless": true,
-  "min_instance_version": "6.15.60"
+  "instance_version": "6.15.60"
 }

--- a/config.json
+++ b/config.json
@@ -1,9 +1,11 @@
 {
   "name": "Add project from ecosystem",
   "type": "app",
-  "categories": ["system"],
+  "categories": [
+    "system"
+  ],
   "description": "Adds project from ecosystem, works with all project types: images / videos / 3d / dicom",
-  "docker_image": "supervisely/system:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/add_project.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.525
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
